### PR TITLE
Nissanleaf

### DIFF
--- a/homeassistant/components/device_tracker/nissan_leaf.py
+++ b/homeassistant/components/device_tracker/nissan_leaf.py
@@ -8,7 +8,7 @@ import logging
 from homeassistant.util import slugify
 from homeassistant.helpers.dispatcher import (
 	dispatcher_connect, dispatcher_send)
-from custom_components.nissan_leaf import DATA_LEAF, SIGNAL_UPDATE_LEAF, DATA_LOCATION
+from homeassistant.components.nissan_leaf import DATA_LEAF, SIGNAL_UPDATE_LEAF, DATA_LOCATION
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/device_tracker/nissan_leaf.py
+++ b/homeassistant/components/device_tracker/nissan_leaf.py
@@ -22,7 +22,7 @@ def setup_scanner(hass, config, see, discovery_info=None):
 
 		for key, value in hass.data[DATA_LEAF].items():
 			host_name = value.leaf.nickname
-			dev_id = 'nissan_leaf{}'.format(slugify(host_name))
+			dev_id = 'nissan_leaf_{}'.format(slugify(host_name))
 			if value.data[DATA_LOCATION] in [None,False]:
 				_LOGGER.debug("No position found for vehicle %s", key)
 				return False

--- a/homeassistant/components/device_tracker/nissan_leaf.py
+++ b/homeassistant/components/device_tracker/nissan_leaf.py
@@ -1,0 +1,39 @@
+"""
+Support for tracking a Nissan Leaf.
+For more details about this platform, please refer to the documentation
+of the main platform component
+"""
+import logging
+
+from homeassistant.util import slugify
+from homeassistant.helpers.dispatcher import (
+	dispatcher_connect, dispatcher_send)
+from custom_components.nissan_leaf import DATA_LEAF, SIGNAL_UPDATE_LEAF, DATA_LOCATION
+
+_LOGGER = logging.getLogger(__name__)
+
+
+def setup_scanner(hass, config, see, discovery_info=None):
+	"""Set up the Nissan Leaf tracker."""
+	_LOGGER.debug("Setting up Scanner (device_tracker) for Nissan Leaf")
+	
+	def see_vehicle():
+		"""Handle the reporting of the vehicle position."""
+
+		for key, value in hass.data[DATA_LEAF].items():
+			host_name = value.leaf.nickname
+			dev_id = 'nissan_leaf{}'.format(slugify(host_name))
+			if value.data[DATA_LOCATION] in [None,False]:
+				_LOGGER.debug("No position found for vehicle %s", key)
+				return False
+			_LOGGER.debug("Updating device_tracker for %s with position %s", value.leaf.nickname, value.data[DATA_LOCATION])
+			see(dev_id=dev_id,
+				host_name=host_name,
+				gps=(value.data[DATA_LOCATION].latitude,
+					 value.data[DATA_LOCATION].longitude),
+				icon='mdi:car')
+
+	dispatcher_connect(hass, SIGNAL_UPDATE_LEAF, see_vehicle)
+	dispatcher_send(hass, SIGNAL_UPDATE_LEAF)
+
+	return True

--- a/homeassistant/components/nissan_leaf.py
+++ b/homeassistant/components/nissan_leaf.py
@@ -82,7 +82,7 @@ CONFIG_SCHEMA = vol.Schema({
 }, extra=vol.ALLOW_EXTRA)
 
 LEAF_COMPONENTS = [
-    'sensor', 'switch', 'binary_sensor'
+    'sensor', 'switch', 'binary_sensor', 'device_tracker'
 ]
 
 SIGNAL_UPDATE_LEAF = 'nissan_leaf_update'
@@ -140,7 +140,7 @@ class LeafDataStore:
         self.leaf = leaf
         self.config = config
         # self.nissan_connect = config[DOMAIN][CONF_NCONNECT]
-        self.nissan_connect = False  # Disabled until tested and implemented
+        self.nissan_connect = config[DOMAIN][CONF_NCONNECT]  # Disabled until tested and implemented
         self.force_miles = config[DOMAIN][CONF_FORCE_MILES]
         self.hass = hass
         self.data = {}

--- a/homeassistant/components/nissan_leaf.py
+++ b/homeassistant/components/nissan_leaf.py
@@ -139,8 +139,7 @@ class LeafDataStore:
     def __init__(self, leaf, hass, config):
         self.leaf = leaf
         self.config = config
-        # self.nissan_connect = config[DOMAIN][CONF_NCONNECT]
-        self.nissan_connect = config[DOMAIN][CONF_NCONNECT]  # Disabled until tested and implemented
+        self.nissan_connect = config[DOMAIN][CONF_NCONNECT]
         self.force_miles = config[DOMAIN][CONF_FORCE_MILES]
         self.hass = hass
         self.data = {}


### PR DESCRIPTION
## Description:
Initial commit of a device_tracker for the nissan_leaf component. Integrates with the setup of the parent component and register in the device_tracker platform

**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io) with documentation (if applicable):** home-assistant/home-assistant.github.io#<home-assistant.github.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.github.io](https://github.com/home-assistant/home-assistant.github.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Local tests with `tox` run successfully. **Your PR cannot be merged unless tests pass**
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
